### PR TITLE
feat: containerize application

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -1,0 +1,67 @@
+name: Container Build and Publish
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  container:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        id: qemu
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: arm64,amd64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=auto
+          tags: |
+            # tag v0.0.1
+            type=ref,event=tag
+            # short commit sha
+            type=sha
+            # set dev tag for master branch
+            type=raw,value=dev,enable=${{ github.event_name == 'workflow_dispatch' }}
+
+      - name: Login to Github Packages
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build image and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: docker/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/docker/.dockerignore
+++ b/docker/.dockerignore
@@ -1,0 +1,4 @@
+Dockerfile
+.git
+docker-compose.yaml
+README.*

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,65 @@
+FROM --platform=${BUILDPLATFORM:-"linux/amd64"} php:8.1.15 as build
+
+COPY --from=composer:2.5.1 /usr/bin/composer /usr/local/bin/composer
+
+RUN --mount=type=cache,sharing=locked,target=/var/cache/apt \
+    apt-get update && \
+    apt-get install -yqq --no-install-recommends \
+    git libzip-dev zip unzip && rm -rf /var/lib/apt/lists/*
+
+RUN docker-php-ext-install zip
+
+WORKDIR /app
+
+COPY . /app
+
+RUN --mount=type=cache,sharing=locked,target=/root/.composer \
+    COMPOSER_ALLOW_SUPERUSER=1 composer install --no-dev --optimize-autoloader --classmap-authoritative --ansi
+
+RUN mkdir -p storage/logs/laravel
+
+FROM php:8.1.15-apache
+COPY --from=composer:2.5.1 /usr/bin/composer /usr/local/bin/composer
+
+# use unprivileged port
+RUN sed -i 's/Listen 80/Listen 8080/g' /etc/apache2/ports.conf
+RUN sed -i 's/:80/:8080/g' /etc/apache2/sites-available/000-default.conf
+
+# fix docroot, as our app is served from ./public/
+ENV APACHE_DOCUMENT_ROOT=/var/www/html/public
+RUN sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/000-default.conf
+
+# cleanup apache modules
+RUN rm -fv /etc/apache2/mods-enabled/* && \
+      a2enmod authz_core alias dir mpm_prefork negotiation php headers rewrite
+
+RUN --mount=type=cache,sharing=locked,target=/var/cache/apt \
+    apt-get update && \
+    apt-get install -yqq --no-install-recommends \
+    default-mysql-client libzip-dev cron && rm -rf /var/lib/apt/lists/*
+
+RUN pecl install -o -f redis \
+    && rm -rf /tmp/pear \
+    && docker-php-ext-enable redis
+
+RUN docker-php-ext-install pdo_mysql zip && docker-php-ext-enable pdo_mysql
+
+RUN cp /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini
+
+WORKDIR /var/www/html
+
+COPY --from=build --chown=33:33 /app /var/www/html
+
+COPY docker/entrypoint.sh /
+
+COPY docker/crontab /etc/cron.d/crontab
+
+RUN crontab -u www-data /etc/cron.d/crontab \
+    && chmod u+s /usr/sbin/cron
+
+EXPOSE 8091
+EXPOSE 8080
+
+USER 33
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/crontab
+++ b/docker/crontab
@@ -1,0 +1,3 @@
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+*/5 * * * * cd /var/www/html && install -d storage/logs/artisan/$(date +"\%Y-\%m-\%d") && php artisan schedule:run >> storage/logs/artisan/$(date +"\%Y-\%m-\%d")/schedule-run.log 2>&1

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,0 +1,66 @@
+version: '3'
+
+services:
+  mysql:
+    image: mysql:8.0.32
+    restart: always
+    hostname: mysql
+    environment:
+      - MYSQL_DATABASE=tracker
+      - MYSQL_USER=tracker
+      - MYSQL_PASSWORD=tracker
+    volumes:
+      - mysql:/var/lib/mysql/
+
+  redis:
+    image: redis:7.0.8-alpine
+    restart: always
+    hostname: redis
+
+  gps-tracker:
+    image: ghcr.io/eusonlito/gps-tracker:latest
+    restart: always
+    depends_on:
+      - mysql
+      - redis
+    ports:
+      - "8080:8080"
+      - "8091:8091"
+    volumes:
+      - logs:/var/www/html/storage/logs
+    environment:
+     - DEFAULT_ADMIN_CREATE=true
+     - DEFAULT_LANGUAGE=en
+     - DEFAULT_TIMEZONE=Europe/Berlin
+     - APP_APP_NAME="GPS-Tracker"
+     - APP_APP_ENV=develop
+     - APP_APP_DEBUG=true
+
+     - APP_DB_HOST=mysql
+     - APP_DB_PORT=3306
+     - APP_DB_DATABASE=tracker
+     - APP_DB_USERNAME=tracker
+     - APP_DB_PASSWORD=tracker
+
+     - APP_QUEUE_CONNECTION=redis
+     - APP_QUEUE_SCHEDULE=true
+
+     - APP_CACHE_ENABLED=true
+     - APP_CACHE_DRIVER=redis
+     - APP_CACHE_PREFIX=tracker-cache-
+     - APP_CACHE_VERSION=1
+     - APP_CACHE_TTL=3600
+
+     - APP_REDIS_CLIENT=phpredis
+     - APP_REDIS_HOST=redis
+     - APP_REDIS_PASSWORD=null
+     - APP_REDIS_PORT=6379
+     - APP_REDIS_QUEUE=tracker
+     - APP_REDIS_PREFIX=tracker-
+     - SESSION_DRIVER=redis
+
+     - APP_DEBUGBAR_ENABLED=true
+
+volumes:
+  mysql:
+  logs:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+DEFAULT_ADMIN_MAIL=${DEFAULT_ADMIN_MAIL:-"admin@local.host"}
+DEFAULT_ADMIN_NAME=${DEFAULT_ADMIN_NAME:-"Admin"}
+DEFAULT_ADMIN_PASS=${DEFAULT_ADMIN_PASS:-"Admin123"}
+DEFAULT_ADMIN_CREATE=${DEFAULT_ADMIN_CREATE:-"false"}
+
+cd /var/www/html
+
+(
+    source .env.example
+    grep '=' .env.example | cut -d'=' -f1 | while read -r var; do eval echo "$var=\${APP_$var:-\$$var}"; done
+) > .env
+
+while ! mysqladmin ping -h"${APP_DB_HOST}" --silent; do
+    echo "Waiting for MySQL (host: ${APP_DB_HOST}) to come up.."
+    sleep 5
+done
+
+php artisan key:generate
+
+composer artisan-cache
+
+php artisan timezone:geojson
+
+yes "yes" | php artisan migrate --path=database/migrations;
+yes "yes" | php artisan db:seed --class=Database\\Seeders\\Database;
+
+if [ ! -z "${DEFAULT_LANGUAGE}" ]
+then
+    mysql \
+        -u${APP_DB_USERNAME} \
+        -p${APP_DB_PASSWORD} \
+        -h${APP_DB_HOST} \
+        ${APP_DB_DATABASE} \
+        -e 'UPDATE `language` SET `default` = 0;'
+
+    mysql \
+        -u${APP_DB_USERNAME} \
+        -p${APP_DB_PASSWORD} \
+        -h${APP_DB_HOST} \
+        ${APP_DB_DATABASE} \
+        -e 'UPDATE `language` SET `default` = 1 WHERE `code` = "'${DEFAULT_LANGUAGE}'";'
+fi
+
+if [ ! -z "${DEFAULT_TIMEZONE}" ]
+then
+    mysql \
+        -u${APP_DB_USERNAME} \
+        -p${APP_DB_PASSWORD} \
+        -h${APP_DB_HOST} \
+        ${APP_DB_DATABASE} \
+        -e 'UPDATE `timezone` SET `default` = 0;'
+
+    mysql \
+        -u${APP_DB_USERNAME} \
+        -p${APP_DB_PASSWORD} \
+        -h${APP_DB_HOST} \
+        ${APP_DB_DATABASE} \
+        -e 'UPDATE `timezone` SET `default` = 1 WHERE `zone` = "'${DEFAULT_TIMEZONE}'";'
+fi
+
+if [ "${DEFAULT_ADMIN_CREATE}" == "true" ]
+then
+    res=$(
+        mysql \
+            -u${APP_DB_USERNAME} \
+            -p${APP_DB_PASSWORD} \
+            -h${APP_DB_HOST} \
+            ${APP_DB_DATABASE} \
+            -sse 'SELECT EXISTS(SELECT * FROM user WHERE email="'${DEFAULT_ADMIN_MAIL}'");'
+    )
+
+    if [ "${res}" = 0 ]
+    then
+        php artisan user:create \
+            --email=${DEFAULT_ADMIN_MAIL} \
+            --name=${DEFAULT_ADMIN_NAME} \
+            --password=${DEFAULT_ADMIN_PASS} \
+            --enabled \
+            --admin
+    fi
+fi
+echo "Starting cron"
+cron
+
+echo "Starting apache"
+exec apache2-foreground


### PR DESCRIPTION
This PR will
- introduce a Dockerfile to build a container image for the app
  - based on official php:httpd container image (Debian based)
  - everything runs rootless (port 8080 for the webapp)
  - has options to override the default timezone, set the default language and automatically create an admin user
  - runs the required cronjob every 5 minutes (although I suppose we could make that adjustable as well, if you prefer)
- introduce a Github Workflow to directly build the container image, both as amd64 and arm64 images
  - either manually (gets tagged with `dev` then)
  - or when pushing a semver tag like `v0.0.1` (gets tagged with `latest` and `v0.0.1` then)